### PR TITLE
Update process.pid with pid of forked child process

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -16,6 +16,17 @@ var fs = require('fs'),
 Object.keys(binding).forEach(function (k) { daemon[k] = binding[k] });
 
 // 
+// function start (fd)
+//   Wrapper around C++ start code to update the pid property of the  
+//   global process js object.  
+//
+daemon.start = function (fd) {
+      var pid = binding.start(fd);
+      process.pid = pid;
+      return pid;
+};
+  
+// 
 // function daemonize ([out, lock, callback])
 //   Run is designed to encapsulate the basic daemon operation in a single async call.
 //   When the callback returns you are in the the child process.
@@ -23,10 +34,10 @@ Object.keys(binding).forEach(function (k) { daemon[k] = binding[k] });
 daemon.daemonize = function (out, lock, callback) {
   //
   // If we only get one argument assume it's an fd and 
-  // simply return with the pid from binding.daemonize(fd);
+  // simply return with the pid from daemon.start(fd);
   //
   if (arguments.length === 1) {
-    return binding.daemonize(out);
+    return daemon.start(out);
   }
   
   fs.open(out, 'a+', 0666, function (err, fd) {


### PR DESCRIPTION
This commit wraps calls to binding.start() with a function that updates the process.pid to reflect the pid of the newly forked child process.  With this change 'process.pid' in the child process will be the actual pid of the child process, not that of the killed parent process.
