### PR TITLE
ABI change + node-waf = need to keep local copies of compiled files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 build/*
 *.swp
+*.node
 node_modules
 npm-debug.log
 fixtures/*

--- a/install
+++ b/install
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+version=`node -v`
+node-waf configure build
+if [ -f build/Release/daemon.node ]; then
+  cp build/Release/daemon.node "lib/daemon.$version.node"
+elif [ -f build/default/daemon.node ]; then
+  cp build/default/daemon.node "lib/daemon.$version.node"
+fi

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -9,12 +9,7 @@
 var fs = require('fs'),
     binding;
 
-//
-// Try catch here around multiple build paths to support
-// `node@0.4.x` and `node@0.6.x`.
-//
-try { binding = require('../build/default/daemon') }
-catch (ex) { binding = require('../build/Release/daemon') }
+binding = require('./daemon.' + process.version);
 
 var daemon = exports;
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "main": "./lib/daemon",
   "scripts" : {
-    "preinstall" : "node-waf configure build"
+    "preinstall" : "bash ./install"
   },
   "engines" : {
      "node" : ">= 0.4.0"


### PR DESCRIPTION
We need to keep copies of compiled .node files to prevent node-waf from getting confused and letting us run clean without nuking .node files built for other ABIs.
