### PR TITLE
Only truncate the lockfile after it's been successfully locked.

### DIFF
--- a/src/daemon.cc
+++ b/src/daemon.cc
@@ -139,12 +139,13 @@ Handle<Value> LockD(const Arguments& args) {
   String::Utf8Value data(args[0]->ToString());
   char pid_str[PID_MAXLEN+1];
   
-  int lfp = open(*data, O_RDWR | O_CREAT | O_TRUNC, 0640);
+  int lfp = open(*data, O_RDWR | O_CREAT, 0640);
   if(lfp < 0) exit(1);
   if(lockf(lfp, F_TLOCK, 0) < 0) return Boolean::New(false);
   
   int len = snprintf(pid_str, PID_MAXLEN, "%d", getpid());
   write(lfp, pid_str, len);
+  ftruncate(lfp, len);
   fsync(lfp);
   
   return Boolean::New(true);


### PR DESCRIPTION
Otherwise, just trying to start a second daemon process will cause the
lockfile contents to get erased.
###### 

Thanks for your consideration,

-dan
