### PR TITLE
Fix: Pass filename down from JS, then open file in C++.

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -20,24 +20,14 @@ Object.keys(binding).forEach(function (k) { daemon[k] = binding[k] });
 
 // 
 // ### function start (stdout, stderr)
-// #### @stdout {fd} File descriptor for the daemon stdout
-// #### @stderr {fd} File descriptor for the daemon stderr
+// #### @stdout {string} Filename to use for the daemon stdout
+// #### @stderr {string} Filename to use for the daemon stderr
 // Wrapper around C++ start code to update the pid property of the  
 // global process js object. If only `stdout` is passed then it is 
 // used for both `stdout` and `stderr` in the daemon process.
 //
 daemon.start = function (stdout, stderr) {
   var pid;
-  
-  process.stdout.write('');
-  process.stderr.write('');
-  
-  if (process._channel) {
-    //
-    // Stops failed assertion when used in forked process
-    //
-    process._channel.close();
-  }
   
   pid = arguments.length === 2
     ? binding.start(stdout, stderr)
@@ -58,28 +48,9 @@ daemon.daemonize = function (out, lock, callback) {
     daemon.lock(lock);
     callback(null, pid);
   }
-  
-  //
-  // If we only get one argument assume it's an fd and 
-  // simply return with the pid from daemon.start(fd);
-  //
+
   if (arguments.length === 1) {
     return start([out]);
-  }
-  
-  function open(paths, fds) {
-    var path = paths.shift();
-    fs.open(path, 'a+', 0666, function (err, fd) {
-      if (err) {
-        //
-        // Remark: Should probably close all fds
-        //
-        return callback(err);
-      }
-      
-      fds.push(fd);
-      return paths.length ? open(paths, fds) : start(fds);
-    });
   }
 
   return typeof out === 'object'


### PR DESCRIPTION
The existing implementation opens a file descriptor asynchronously in javascript, then passes the integer returned down to C++, and expects the file table to still be in the same state after a `fork(2)`.  Sometimes, this just fails and log files are mysteriously empty - in general, this seems to leak a fair bit of memory.

This patch changes things around so that a filename is instead taken as an argument in javascript, and the file descriptor is not opened until after the `fork(2)` call.

This simplification so far seems to prevent the stdio-related issues, and has, according to local testing, eliminated at least most of the memory leak.

I've also removed the `SetSid()` method.  Put briefly, it shouldn't be exposed to javascript by itself.

This should be released with a minor version bump, as it breaks the call signature of `daemon.start`, which now takes string filenames instead of file descriptors.
