### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # daemon
 
 [![Build Status](https://secure.travis-ci.org/indexzero/daemon.node.png)](http://travis-ci.org/indexzero/daemon.node)
+[![Inline docs](http://inch-ci.org/github/indexzero/daemon.node.svg?branch=master)](http://inch-ci.org/github/indexzero/daemon.node)
 
 Turn a node script into a daemon.
 


### PR DESCRIPTION
Hi there,

you have recently tried to evaluate this project via Inch. I took the liberty to make a badge for you: [![Inline docs](http://inch-ci.org/github/indexzero/daemon.node.svg)](http://inch-ci.org/github/indexzero/daemon.node)


The badge shows an evaluation by [InchJS](http://trivelop.de/inchjs), but I guess you already knew that. :wink: 

I would really like to roll out support for JS over the coming weeks (early adopters are [forever](https://github.com/foreverjs/forever), [node-sass](https://github.com/sass/node-sass) and [Shipit](https://github.com/shipitjs/shipit)).

Although this is "only" a passion project, I really would like to hear your thoughts, critique and suggestions. Your status page is http://inch-ci.org/github/indexzero/daemon.node

What do you think?