### PR TITLE
Added "uid" and "pidfile" options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ opt can optionally contain the following arguments:
 * stderr (file descriptor for stderr of the daemon)
 * env (environment for the daemon) (default: process.env)
 * cwd (current working directory for daemonized script) (default: process.cwd)
+* uid (child process user ID, either numeric or a name that can be looked up in /etc/passwd)
+* pidfile (the fully qualified name of a file to write the daemon's PID to)
 
 ## implementation notes
 

--- a/examples/cluster.js
+++ b/examples/cluster.js
@@ -2,6 +2,9 @@ var cluster = require('cluster');
 var numCPUs = require('os').cpus().length;
 
 if (cluster.isMaster) {
+    // Daemonize before forking if you want the "uid" option to be useful.
+    require('../')();
+
     // Fork workers.
     for (var i = 0; i < numCPUs; ++i) {
         cluster.fork();
@@ -12,8 +15,7 @@ if (cluster.isMaster) {
         cluster.fork();
     });
 
-    // daemonize after setting up cluster
-    return require('../')();
+    return;
 }
 
 var http = require('http');


### PR DESCRIPTION
"uid" allows you to drop priveleges after daemonizing. Its argument can
either be a numeric UID or a username that can be found in /etc/passwd.

"pidfile" is the name of a file to write the daemon's PID to. For daemons
that fork, none of the children will have their PIDs added to the file.