### PR TITLE
FIX #41 "cwd" must be a string in Node 8

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports.daemon = function(script, args, opt) {
     var stderr = opt.stderr || 'ignore';
 
     var env = opt.env || process.env;
-    var cwd = opt.cwd || process.cwd;
+    var cwd = opt.cwd || process.cwd();
 
     var cp_opt = {
         stdio: ['ignore', stdout, stderr],


### PR DESCRIPTION
The fix is quite obvious, but i really really don't know what was happening before Node 8 decided to enforce the parameters validation  of `child_process.spawn()` ?